### PR TITLE
HDA-2208 Add 'npm run build' to integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -64,6 +64,7 @@ jobs:
         run: npm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_TOKEN }}
 
       - run: npm ci --ignore-scripts
+      - run: npm run build
       - run: npm run migration:run
       - run: npm run start:pm2
       - run: npm run integration-tests


### PR DESCRIPTION
Required as `npm run migration:run` now uses a [transpiled datasource from `dist/`](https://github.com/hedia-team/service-template/blob/hda-2208-update-typeorm/package.json#L35).